### PR TITLE
Revert "fix(images): update helm values ghcr.io/k8s-at-home/wireguard to v1.0.20210914"

### DIFF
--- a/k8s/manifests/vpn/downloads-gateway/helmrelease.yaml
+++ b/k8s/manifests/vpn/downloads-gateway/helmrelease.yaml
@@ -63,7 +63,7 @@ spec:
         wireguard:
           image:
             repository: ghcr.io/k8s-at-home/wireguard
-            tag: v1.0.20210914
+            tag: v1.0.20210424
             pullPolicy: IfNotPresent
 
         securityContext:


### PR DESCRIPTION
Reverts Truxnell/home-cluster#739