### PR TITLE
Revert "fix(charts): update helm release metallb to v2.6.8"

### DIFF
--- a/k8s/manifests/network-system/metallb/helmrelease.yaml
+++ b/k8s/manifests/network-system/metallb/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       # renovate: registryUrl=https://charts.bitnami.com/bitnami
       chart: metallb
-      version: 2.6.8
+      version: 2.6.2
       sourceRef:
         kind: HelmRepository
         name: bitnami-charts


### PR DESCRIPTION
Reverts Truxnell/home-cluster#756