### PR TITLE
Revert ":arrow_up: feat(container)!: Update Docker image ghcr.io/linuxserver/calibre-web to version-v5.7.2"

### DIFF
--- a/k8s/manifests/user/organizarrs/calibre-web/helmrelease.yaml
+++ b/k8s/manifests/user/organizarrs/calibre-web/helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
   values:
     image:
       repository: ghcr.io/linuxserver/calibre-web
-      tag: version-v5.7.2
+      tag: version-0.6.18
 
     env:
       TZ: "${TZ}"


### PR DESCRIPTION
Reverts Truxnell/home-cluster#1059