### PR TITLE
Revert ":arrow_up: fix(helm): Update Helm chart node-problem-detector to 2.2.2"

### DIFF
--- a/k8s/manifests/user/kube-system/node-problem-detector/helmrelease.yaml
+++ b/k8s/manifests/user/kube-system/node-problem-detector/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: node-problem-detector
-      version: 2.2.2
+      version: 2.2.1
       sourceRef:
         kind: HelmRepository
         name: deliveryhero-charts


### PR DESCRIPTION
Reverts Truxnell/home-cluster#1270