### PR TITLE
Revert ":arrow_up: fix(container): Update Docker image ghcr.io/koenkk/zigbee2mqtt to 1.25.2"

### DIFF
--- a/k8s/manifests/user/home-automation/zigbee2mqtt/helmrelease.yaml
+++ b/k8s/manifests/user/home-automation/zigbee2mqtt/helmrelease.yaml
@@ -30,7 +30,7 @@ spec:
   values:
     image:
       repository: ghcr.io/koenkk/zigbee2mqtt
-      tag: 1.25.2
+      tag: 1.25.1
 
     podAnnotations:
       configmap.reloader.stakater.com/reload: "zigbee2mqtt-settings"


### PR DESCRIPTION
Reverts Truxnell/home-cluster#1302

Failed to pull image "ghcr.io/koenkk/zigbee2mqtt:1.25.2": rpc error: code = NotFound desc = failed to pull and unpack image "ghcr.io/koenkk/zigbee2mqtt:1.25.2": failed to copy: httpReadSeeker: failed open: content at https://ghcr.io/v2/koenkk/zigbee2mqtt/manifests/sha256:63812d7a77ad6ab414cfb597ae8934dcb9d1bc665515b32db22b56b5298a6249 not found: not found