### PR TITLE
Revert ":arrow_up: fix(container): Update Docker image ghcr.io/koenkk/zigbee2mqtt to 1.25.2"

### DIFF
--- a/k8s/manifests/user/home-automation/zigbee2mqtt/helmrelease.yaml
+++ b/k8s/manifests/user/home-automation/zigbee2mqtt/helmrelease.yaml
@@ -30,7 +30,7 @@ spec:
   values:
     image:
       repository: ghcr.io/koenkk/zigbee2mqtt
-      tag: 1.25.2
+      tag: 1.25.1
 
     podAnnotations:
       configmap.reloader.stakater.com/reload: "zigbee2mqtt-settings"


### PR DESCRIPTION
Reverts Truxnell/home-cluster#1310

container image still missing