### PR TITLE
Revert ":arrow_up: fix(container): update Docker image ghcr.io/k8s-at-home/sonarr-nightly to v4.0.0.2162"

### DIFF
--- a/k8s/manifests/user/organizarrs/sonarr/helmrelease.yaml
+++ b/k8s/manifests/user/organizarrs/sonarr/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
     controllerType: deployment
     image:
       repository: ghcr.io/k8s-at-home/sonarr-nightly
-      tag: v4.0.0.2162
+      tag: v4.0.0.2158
 
     env:
       TZ: "${TZ}"


### PR DESCRIPTION
Reverts Truxnell/home-cluster#1353